### PR TITLE
Refine pagination response structure

### DIFF
--- a/src/main/java/com/app/playerservicejava/controller/PlayerController.java
+++ b/src/main/java/com/app/playerservicejava/controller/PlayerController.java
@@ -20,8 +20,11 @@ public class PlayerController {
     private PlayerService playerService;
 
     @RequestMapping(method = RequestMethod.GET)
-    public ResponseEntity<Players> getPlayers() {
-        Players players = playerService.getPlayers();
+    public ResponseEntity<Players> getPlayers(
+            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(value = "size", required = false, defaultValue = "10") int size
+    ) {
+        Players players = playerService.getPlayers(page, size);
         return ok(players);
     }
 

--- a/src/main/java/com/app/playerservicejava/controller/PlayerController.java
+++ b/src/main/java/com/app/playerservicejava/controller/PlayerController.java
@@ -3,26 +3,35 @@ package com.app.playerservicejava.controller;
 import com.app.playerservicejava.model.Player;
 import com.app.playerservicejava.model.Players;
 import com.app.playerservicejava.service.PlayerService;
-import jakarta.annotation.Resource;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
 
 import static org.springframework.http.ResponseEntity.ok;
 
+@Validated
 @RestController
 @RequestMapping(value = "v1/players", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class PlayerController {
-    @Resource
-    private PlayerService playerService;
+    private final PlayerService playerService;
 
-    @RequestMapping(method = RequestMethod.GET)
+    public PlayerController(PlayerService playerService) {
+        this.playerService = playerService;
+    }
+
+    @GetMapping
     public ResponseEntity<Players> getPlayers(
-            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
-            @RequestParam(value = "size", required = false, defaultValue = "10") int size
+            @RequestParam(value = "page", defaultValue = "0") @Min(0) int page,
+            @RequestParam(value = "size", defaultValue = "10") @Min(1) int size
     ) {
         Players players = playerService.getPlayers(page, size);
         return ok(players);

--- a/src/main/java/com/app/playerservicejava/model/PageMetadata.java
+++ b/src/main/java/com/app/playerservicejava/model/PageMetadata.java
@@ -1,0 +1,53 @@
+package com.app.playerservicejava.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+
+/**
+ * Represents metadata associated with a paginated collection response.
+ */
+public class PageMetadata implements Serializable {
+    private final long totalElements;
+    private final int totalPages;
+    private final int page;
+    private final int size;
+
+    public PageMetadata() {
+        this(0L, 0, 0, 0);
+    }
+
+    @JsonCreator
+    public PageMetadata(
+            @JsonProperty("totalElements") long totalElements,
+            @JsonProperty("totalPages") int totalPages,
+            @JsonProperty("page") int page,
+            @JsonProperty("size") int size
+    ) {
+        this.totalElements = Math.max(totalElements, 0L);
+        this.totalPages = Math.max(totalPages, 0);
+        this.page = Math.max(page, 0);
+        this.size = Math.max(size, 0);
+    }
+
+    public static PageMetadata empty() {
+        return new PageMetadata();
+    }
+
+    public long getTotalElements() {
+        return totalElements;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+}

--- a/src/main/java/com/app/playerservicejava/model/Players.java
+++ b/src/main/java/com/app/playerservicejava/model/Players.java
@@ -4,20 +4,75 @@ package com.app.playerservicejava.model;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class Players implements Serializable {
     private List<Player> players;
+    private PageMetadata metadata;
 
     public Players() {
-        this.players = new ArrayList<>();
+        this(new ArrayList<>(), new PageMetadata());
+    }
+
+    public Players(List<Player> players, PageMetadata metadata) {
+        this.players = players == null ? new ArrayList<>() : new ArrayList<>(players);
+        this.metadata = metadata == null ? new PageMetadata() : metadata;
     }
 
     public List<Player> getPlayers() {
-        return players;
+        return Collections.unmodifiableList(players);
     }
 
     public void setPlayers(List<Player> players) {
-        this.players = players;
+        this.players = players == null ? new ArrayList<>() : new ArrayList<>(players);
+    }
+
+    public PageMetadata getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(PageMetadata metadata) {
+        this.metadata = Objects.requireNonNullElseGet(metadata, PageMetadata::new);
+    }
+
+    public static class PageMetadata implements Serializable {
+        private long totalElements;
+        private int totalPages;
+        private int page;
+        private int size;
+
+        public long getTotalElements() {
+            return totalElements;
+        }
+
+        public void setTotalElements(long totalElements) {
+            this.totalElements = totalElements;
+        }
+
+        public int getTotalPages() {
+            return totalPages;
+        }
+
+        public void setTotalPages(int totalPages) {
+            this.totalPages = totalPages;
+        }
+
+        public int getPage() {
+            return page;
+        }
+
+        public void setPage(int page) {
+            this.page = page;
+        }
+
+        public int getSize() {
+            return size;
+        }
+
+        public void setSize(int size) {
+            this.size = size;
+        }
     }
 }

--- a/src/main/java/com/app/playerservicejava/model/Players.java
+++ b/src/main/java/com/app/playerservicejava/model/Players.java
@@ -1,78 +1,40 @@
 package com.app.playerservicejava.model;
 
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 public class Players implements Serializable {
-    private List<Player> players;
-    private PageMetadata metadata;
+    private final List<Player> players;
+    private final PageMetadata metadata;
 
     public Players() {
-        this(new ArrayList<>(), new PageMetadata());
+        this(Collections.emptyList(), PageMetadata.empty());
     }
 
-    public Players(List<Player> players, PageMetadata metadata) {
-        this.players = players == null ? new ArrayList<>() : new ArrayList<>(players);
-        this.metadata = metadata == null ? new PageMetadata() : metadata;
+    @JsonCreator
+    public Players(
+            @JsonProperty("players") List<Player> players,
+            @JsonProperty("metadata") PageMetadata metadata
+    ) {
+        List<Player> safePlayers = players == null ? Collections.emptyList() : new ArrayList<>(players);
+        this.players = Collections.unmodifiableList(safePlayers);
+        this.metadata = metadata == null ? PageMetadata.empty() : metadata;
+    }
+
+    public static Players of(List<Player> players, PageMetadata metadata) {
+        return new Players(players, metadata);
     }
 
     public List<Player> getPlayers() {
-        return Collections.unmodifiableList(players);
-    }
-
-    public void setPlayers(List<Player> players) {
-        this.players = players == null ? new ArrayList<>() : new ArrayList<>(players);
+        return players;
     }
 
     public PageMetadata getMetadata() {
         return metadata;
-    }
-
-    public void setMetadata(PageMetadata metadata) {
-        this.metadata = Objects.requireNonNullElseGet(metadata, PageMetadata::new);
-    }
-
-    public static class PageMetadata implements Serializable {
-        private long totalElements;
-        private int totalPages;
-        private int page;
-        private int size;
-
-        public long getTotalElements() {
-            return totalElements;
-        }
-
-        public void setTotalElements(long totalElements) {
-            this.totalElements = totalElements;
-        }
-
-        public int getTotalPages() {
-            return totalPages;
-        }
-
-        public void setTotalPages(int totalPages) {
-            this.totalPages = totalPages;
-        }
-
-        public int getPage() {
-            return page;
-        }
-
-        public void setPage(int page) {
-            this.page = page;
-        }
-
-        public int getSize() {
-            return size;
-        }
-
-        public void setSize(int size) {
-            this.size = size;
-        }
     }
 }

--- a/src/main/java/com/app/playerservicejava/service/PlayerService.java
+++ b/src/main/java/com/app/playerservicejava/service/PlayerService.java
@@ -6,6 +6,9 @@ import com.app.playerservicejava.repository.PlayerRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -17,10 +20,22 @@ public class PlayerService {
     @Autowired
     private PlayerRepository playerRepository;
 
-    public Players getPlayers() {
+    public Players getPlayers(int page, int size) {
+        int sanitizedPage = Math.max(page, 0);
+        int sanitizedSize = size > 0 ? size : 10;
+
+        Pageable pageable = PageRequest.of(sanitizedPage, sanitizedSize);
+        Page<Player> playerPage = playerRepository.findAll(pageable);
+
         Players players = new Players();
-        playerRepository.findAll()
-                .forEach(players.getPlayers()::add);
+        players.setPlayers(playerPage.getContent());
+
+        Players.PageMetadata metadata = new Players.PageMetadata();
+        metadata.setTotalElements(playerPage.getTotalElements());
+        metadata.setTotalPages(playerPage.getTotalPages());
+        metadata.setPage(playerPage.getNumber());
+        metadata.setSize(playerPage.getSize());
+        players.setMetadata(metadata);
         return players;
     }
 

--- a/src/main/java/com/app/playerservicejava/service/PlayerService.java
+++ b/src/main/java/com/app/playerservicejava/service/PlayerService.java
@@ -1,11 +1,11 @@
 package com.app.playerservicejava.service;
 
+import com.app.playerservicejava.model.PageMetadata;
 import com.app.playerservicejava.model.Player;
 import com.app.playerservicejava.model.Players;
 import com.app.playerservicejava.repository.PlayerRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -17,26 +17,24 @@ import java.util.Optional;
 public class PlayerService {
     private static final Logger LOGGER = LoggerFactory.getLogger(PlayerService.class);
 
-    @Autowired
-    private PlayerRepository playerRepository;
+    private final PlayerRepository playerRepository;
+
+    public PlayerService(PlayerRepository playerRepository) {
+        this.playerRepository = playerRepository;
+    }
 
     public Players getPlayers(int page, int size) {
-        int sanitizedPage = Math.max(page, 0);
-        int sanitizedSize = size > 0 ? size : 10;
-
-        Pageable pageable = PageRequest.of(sanitizedPage, sanitizedSize);
+        Pageable pageable = PageRequest.of(page, size);
         Page<Player> playerPage = playerRepository.findAll(pageable);
 
-        Players players = new Players();
-        players.setPlayers(playerPage.getContent());
+        PageMetadata metadata = new PageMetadata(
+                playerPage.getTotalElements(),
+                playerPage.getTotalPages(),
+                playerPage.getNumber(),
+                playerPage.getSize()
+        );
 
-        Players.PageMetadata metadata = new Players.PageMetadata();
-        metadata.setTotalElements(playerPage.getTotalElements());
-        metadata.setTotalPages(playerPage.getTotalPages());
-        metadata.setPage(playerPage.getNumber());
-        metadata.setSize(playerPage.getSize());
-        players.setMetadata(metadata);
-        return players;
+        return Players.of(playerPage.getContent(), metadata);
     }
 
     public Optional<Player> getPlayerById(String playerId) {
@@ -45,12 +43,11 @@ public class PlayerService {
         /* simulated network delay */
         try {
             player = playerRepository.findById(playerId);
-            Thread.sleep((long)(Math.random() * 2000));
+            Thread.sleep((long) (Math.random() * 2000));
         } catch (Exception e) {
             LOGGER.error("message=Exception in getPlayerById; exception={}", e.toString());
             return Optional.empty();
         }
         return player;
     }
-
 }


### PR DESCRIPTION
## Summary
- wrap pagination details for the `Players` response inside a dedicated `PageMetadata` object
- copy player data defensively when constructing responses to avoid unintended mutations
- update the service to populate the new metadata structure while preserving pagination behaviour

## Testing
- `mvn -q test` *(fails: Maven cannot download the Spring Boot parent POM from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f1d46d248326b5eeb3c7f4c12522