### PR TITLE
Add controller advice and error handling for player lookups

### DIFF
--- a/src/main/java/com/app/playerservicejava/controller/PlayerController.java
+++ b/src/main/java/com/app/playerservicejava/controller/PlayerController.java
@@ -1,38 +1,41 @@
 package com.app.playerservicejava.controller;
 
+import com.app.playerservicejava.exception.PlayerNotFoundException;
 import com.app.playerservicejava.model.Player;
 import com.app.playerservicejava.model.Players;
 import com.app.playerservicejava.service.PlayerService;
-import jakarta.annotation.Resource;
-import org.springframework.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Optional;
-
-import static org.springframework.http.ResponseEntity.ok;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "v1/players", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class PlayerController {
-    @Resource
-    private PlayerService playerService;
+    private static final Logger logger = LoggerFactory.getLogger(PlayerController.class);
+
+    private final PlayerService playerService;
+
+    public PlayerController(PlayerService playerService) {
+        this.playerService = playerService;
+    }
 
     @RequestMapping(method = RequestMethod.GET)
     public ResponseEntity<Players> getPlayers() {
         Players players = playerService.getPlayers();
-        return ok(players);
+        return ResponseEntity.ok(players);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<Player> getPlayerById(@PathVariable("id") String id) {
-        Optional<Player> player = playerService.getPlayerById(id);
-
-        if (player.isPresent()) {
-            return new ResponseEntity<>(player.get(), HttpStatus.OK);
-        } else {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        }
+        logger.debug("Fetching player with id {}", id);
+        Player player = playerService.getPlayerById(id)
+                .orElseThrow(() -> new PlayerNotFoundException(id));
+        return ResponseEntity.ok(player);
     }
 }

--- a/src/main/java/com/app/playerservicejava/controller/PlayerControllerAdvice.java
+++ b/src/main/java/com/app/playerservicejava/controller/PlayerControllerAdvice.java
@@ -1,0 +1,31 @@
+package com.app.playerservicejava.controller;
+
+import com.app.playerservicejava.exception.ErrorResponse;
+import com.app.playerservicejava.exception.PlayerNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+
+@RestControllerAdvice(assignableTypes = PlayerController.class)
+public class PlayerControllerAdvice {
+    private static final Logger logger = LoggerFactory.getLogger(PlayerControllerAdvice.class);
+    private static final String GENERIC_ERROR_MESSAGE = "An unexpected error occurred";
+
+    @ExceptionHandler(PlayerNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePlayerNotFound(PlayerNotFoundException exception) {
+        ErrorResponse response = new ErrorResponse(exception.getMessage(), Instant.now());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpectedException(Exception exception) {
+        logger.error("Unexpected error while processing request", exception);
+        ErrorResponse response = new ErrorResponse(GENERIC_ERROR_MESSAGE, Instant.now());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/src/main/java/com/app/playerservicejava/exception/ErrorResponse.java
+++ b/src/main/java/com/app/playerservicejava/exception/ErrorResponse.java
@@ -1,0 +1,6 @@
+package com.app.playerservicejava.exception;
+
+import java.time.Instant;
+
+public record ErrorResponse(String message, Instant timestamp) {
+}

--- a/src/main/java/com/app/playerservicejava/exception/PlayerNotFoundException.java
+++ b/src/main/java/com/app/playerservicejava/exception/PlayerNotFoundException.java
@@ -1,0 +1,14 @@
+package com.app.playerservicejava.exception;
+
+public class PlayerNotFoundException extends RuntimeException {
+    private final String playerId;
+
+    public PlayerNotFoundException(String playerId) {
+        super("Player with id %s not found".formatted(playerId));
+        this.playerId = playerId;
+    }
+
+    public String getPlayerId() {
+        return playerId;
+    }
+}

--- a/src/test/java/com/app/playerservicejava/controller/PlayerControllerTest.java
+++ b/src/test/java/com/app/playerservicejava/controller/PlayerControllerTest.java
@@ -1,0 +1,55 @@
+package com.app.playerservicejava.controller;
+
+import com.app.playerservicejava.service.PlayerService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlayerController.class)
+class PlayerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PlayerService playerService;
+
+    @Test
+    @DisplayName("Should return 404 when player is not found")
+    void getPlayerByIdWhenPlayerMissingReturnsNotFound() throws Exception {
+        given(playerService.getPlayerById("missing")).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/v1/players/missing")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("Player with id missing not found"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @DisplayName("Should return 500 when service throws unexpected exception")
+    void getPlayerByIdWhenServiceThrowsReturnsServerError() throws Exception {
+        when(playerService.getPlayerById("error")).thenThrow(new RuntimeException("boom"));
+
+        mockMvc.perform(get("/v1/players/error")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("An unexpected error occurred"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+}


### PR DESCRIPTION
## Summary
- add custom runtime exception and error response DTO for player lookups
- update the player controller to use the new exception semantics and logging
- introduce controller advice to return consistent 404 and 500 payloads
- cover the new error handling with MockMvc controller tests

## Testing
- mvn test *(fails: unable to resolve Spring Boot parent from Maven Central — HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d602dfb2d88326be7684567ae44709