### PR TITLE
Add Caffeine caching for player lookups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,14 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
@@ -61,10 +69,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>io.github.ollama4j</groupId>

--- a/src/main/java/com/app/playerservicejava/PlayerServiceJavaApplication.java
+++ b/src/main/java/com/app/playerservicejava/PlayerServiceJavaApplication.java
@@ -2,8 +2,10 @@ package com.app.playerservicejava;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class PlayerServiceJavaApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/app/playerservicejava/config/CacheConfig.java
+++ b/src/main/java/com/app/playerservicejava/config/CacheConfig.java
@@ -1,0 +1,23 @@
+package com.app.playerservicejava.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("players");
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(5, TimeUnit.MINUTES)
+                .maximumSize(1_000));
+        return cacheManager;
+    }
+}
+

--- a/src/main/java/com/app/playerservicejava/service/PlayerService.java
+++ b/src/main/java/com/app/playerservicejava/service/PlayerService.java
@@ -6,6 +6,7 @@ import com.app.playerservicejava.repository.PlayerRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -24,6 +25,7 @@ public class PlayerService {
         return players;
     }
 
+    @Cacheable(cacheNames = "players", key = "#playerId")
     public Optional<Player> getPlayerById(String playerId) {
         Optional<Player> player = null;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
   h2:
     console:
       enabled: true
+  cache:
+    type: caffeine
+    cache-names:
+      - players
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- add Spring cache and Caffeine dependencies to support in-memory caching
- enable caching and configure a Caffeine cache manager with TTL and size limits
- cache player lookups with @Cacheable and register cache settings in application.yml

## Testing
- `mvn test` *(fails: unable to download parent POM due to 403 from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc39c10608326893ed091e91feb3e